### PR TITLE
Add read the docs config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,13 @@
+# Use the latest build image to get access to the most Python versions
+build:
+    image: latest
+
+# Must use 3.4+ to get the ABC modules
+python:
+    version: 3.5
+
+# Don't build any extra formats
+formats: []
+
+# You could potentially use a separate requirements file for doc-building - one that doesn't have CoolProp
+requirements_file: requirements/docs.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- Project information -----------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ nose
 numpy
 scipy
 sphinx
+sphinx_rtd_theme
 tox
 pandas


### PR DESCRIPTION
I didn't know ReadTheDocs allowed a config file.  But here you go.  The root of the problem is that ReadTheDocs by default uses Python 2, which doesn't have the abc module, which causes the build to fail.  This tells it to use 3.5, so it should be good.

It would be nice if we could split up the requirements file so that we didn't have to pip install everything every time just to build the docs.  There is a way to do this, you have to 'mock' libraries, but it's too much overhead as long as the docs build.  If they don't build then we can investigate that further.

Anyway, this should be building I believe now.  You can test the build locally running make html inside the docs folder.  And if RTD is set up to build the branches, then this should be going over there too.