### PR TITLE
Update g-function interpolation methods

### DIFF
--- a/glhe/gFunction/main.py
+++ b/glhe/gFunction/main.py
@@ -1,3 +1,5 @@
+from math import log
+
 from numpy import genfromtxt
 from scipy.interpolate import interp1d
 
@@ -13,7 +15,7 @@ class GFunction(SimulationEntryPoint):
 
         # g-function properties
         g_functions = genfromtxt(inputs['g-functions']['file'], delimiter=',')
-        self.g_function = interp1d(g_functions[:, 0], g_functions[:, 1], fill_value='extrapolate')
+        self._g_function = interp1d(g_functions[:, 0], g_functions[:, 1], fill_value='extrapolate')
         self.average_depth = inputs['g-functions']['average-depth']
         self.soil = PropertiesBase(
             conductivity=inputs['soil']['conductivity'],
@@ -24,6 +26,11 @@ class GFunction(SimulationEntryPoint):
         # initialize time here
         self.current_time = 0
         self.load_aggregation = load_agg_factory(inputs['load-aggregation'])
+        self.t_s = self.average_depth ** 2 / (9 * self.soil.diffusivity)
+
+    def get_g_func(self, time):
+        lntts = log(time / self.t_s)
+        return self._g_function(lntts)
 
     def simulate_time_step(self, inlet_temperature, flow, time_step):
         self.current_time += time_step

--- a/tests/glhe/gFunction/test_main.py
+++ b/tests/glhe/gFunction/test_main.py
@@ -18,12 +18,12 @@ class TestGFunction(unittest.TestCase):
         input_structure = {
             'g-functions': {
                 'file': temp_g_function_file,
-                'average-depth': 20,
+                'average-depth': 90,
             },
             'soil': {
-                'conductivity': 1,
-                'density': 2,
-                'specific heat': 3,
+                'conductivity': 1.5,
+                'density': 1500,
+                'specific heat': 1000,
             },
             'load-aggregation': {
                 'type': 'dynamic'
@@ -44,9 +44,15 @@ class TestGFunction(unittest.TestCase):
         self.assertIsInstance(response, TimeStepSimulationResponse)
         self.assertAlmostEqual(response.outlet_temperature, 20.0, 2)
 
-    def test_g_function(self):
+    def test_g_function_interp(self):
         g = self.add_instance()
-        self.assertEqual(g.g_function(0.5), 0.5)
-        self.assertEqual(g.g_function(1.5), 1.5)
-        self.assertEqual(g.g_function(2.5), 2.5)
-        self.assertEqual(g.g_function(3.5), 3.5)
+        self.assertEqual(g._g_function(0.5), 0.5)
+        self.assertEqual(g._g_function(1.5), 1.5)
+        self.assertEqual(g._g_function(2.5), 2.5)
+        self.assertEqual(g._g_function(3.5), 3.5)
+
+    def test_get_g_func(self):
+        g = self.add_instance()
+        self.assertAlmostEqual(g.get_g_func(2446453645.61), 1.0, delta=0.000001)
+        self.assertAlmostEqual(g.get_g_func(6650150489.04), 2.0, delta=0.000001)
+        self.assertAlmostEqual(g.get_g_func(18076983230.9), 3.0, delta=0.000001)


### PR DESCRIPTION
I realized after completing #37 that we would want to pass actual, not log time in to the g-function interpolation routine. This clean up the usage.