### PR TITLE
Run g-function from command line

### DIFF
--- a/standalone/run_g_function.py
+++ b/standalone/run_g_function.py
@@ -4,6 +4,8 @@ import sys
 
 from scipy.optimize import minimize
 
+sys.path.insert(0, os.path.abspath('../'))
+
 from glhe.gFunction.g_function import GFunction
 from glhe.globals.errors import SimulationError
 from glhe.globals.functions import set_time_step

--- a/standalone/run_g_function.py
+++ b/standalone/run_g_function.py
@@ -6,16 +6,16 @@ from scipy.optimize import minimize
 
 sys.path.insert(0, os.path.abspath('../'))
 
-from glhe.gFunction.g_function import GFunction
-from glhe.globals.errors import SimulationError
-from glhe.globals.functions import set_time_step
-from glhe.globals.variables import gv
-from glhe.inputProcessor.processor import InputProcessor
-from glhe.interface.response import TimeStepSimulationResponse
-from glhe.outputProcessor.processor import OutputProcessor
-from glhe.profiles.factory_flow import make_flow_profile
-from glhe.profiles.factory_load import make_load_profile
-from glhe.properties.fluid import Fluid
+from glhe.gFunction.g_function import GFunction  # noqa
+from glhe.globals.errors import SimulationError  # noqa
+from glhe.globals.functions import set_time_step  # noqa
+from glhe.globals.variables import gv  # noqa
+from glhe.inputProcessor.processor import InputProcessor  # noqa
+from glhe.interface.response import TimeStepSimulationResponse  # noqa
+from glhe.outputProcessor.processor import OutputProcessor  # noqa
+from glhe.profiles.factory_flow import make_flow_profile  # noqa
+from glhe.profiles.factory_load import make_load_profile  # noqa
+from glhe.properties.fluid import Fluid  # noqa
 
 
 class RunGFunctions(object):


### PR DESCRIPTION
@Myoldmopar 

I'm having trouble getting this to work.

```
(glhe) mitchute:GLHE mattmitchell$ python /Users/mattmitchell/Projects/GLHE/standalone/run_g_function.py /Users/mattmitchell/Projects/GLHE/studies/aggregation/soil/runs/2.2_2000_704/annual/in.json
Traceback (most recent call last):
  File "/Users/mattmitchell/Projects/GLHE/standalone/run_g_function.py", line 9, in <module>
    from glhe.gFunction.g_function import GFunction
ImportError: No module named 'glhe'
```

I thought we could insert the path to the glhe project as we did with the study files, but this isn't working the same way for some reason. 

Any ideas?

See the below commit. Thanks!